### PR TITLE
Handle error in MM and RG api

### DIFF
--- a/src/main/scala/it/agilelab/bigdata/gis/domain/exceptions/package.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/exceptions/package.scala
@@ -1,0 +1,18 @@
+package it.agilelab.bigdata.gis.domain
+
+package object exceptions {
+
+  /**
+  * Reverse geocoding error.
+  *
+  * @param ex error cause.
+  */
+  case class ReverseGeocodingError(ex: Throwable)
+
+  /**
+  * Matcher route error.
+  *
+  * @param ex error reason.
+  */
+  case class MatchedRouteError(ex: Throwable)
+}

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/GraphHopperManager.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/GraphHopperManager.scala
@@ -5,6 +5,7 @@ import com.graphhopper.util.details.PathDetailsBuilderFactory
 import com.typesafe.config.Config
 import it.agilelab.bigdata.gis.core.utils.Logger
 import it.agilelab.bigdata.gis.domain.configuration.GraphHopperConfiguration
+import it.agilelab.bigdata.gis.domain.exceptions.MatchedRouteError
 import it.agilelab.bigdata.gis.domain.loader.RouteMatcher
 
 import java.util
@@ -150,7 +151,7 @@ case class GraphHopperManager(conf: Config) extends RouteMatcher with Logger {
       } else
           Right(MatchedRoute(gpsPoints.map(_.toTracePoint), length, time, Map.empty, Seq.empty))
     } catch {
-      case ex: _ => Left(MatchedRouteError(ex))
+      case ex: Throwable => Left(MatchedRouteError(ex))
     }
   }
 }

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/GraphHopperManager.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/GraphHopperManager.scala
@@ -1,6 +1,6 @@
 package it.agilelab.bigdata.gis.domain.graphhopper
 
-import com.graphhopper.matching.{EdgeMatch, GPXExtension, MatchResult}
+import com.graphhopper.matching.{EdgeMatch, GPXExtension}
 import com.graphhopper.util.details.PathDetailsBuilderFactory
 import com.typesafe.config.Config
 import it.agilelab.bigdata.gis.core.utils.Logger
@@ -9,7 +9,6 @@ import it.agilelab.bigdata.gis.domain.loader.RouteMatcher
 
 import java.util
 import scala.collection.JavaConversions._
-import scala.util.{Failure, Success, Try}
 
 case class GraphHopperManager(conf: Config) extends RouteMatcher with Logger {
 
@@ -20,143 +19,138 @@ case class GraphHopperManager(conf: Config) extends RouteMatcher with Logger {
       //TODO is this right?
       .getOrElse("unclassified")
 
-  @throws(classOf[RuntimeException])
-  @throws(classOf[IllegalAccessException])
-  private def getMatchingRoute(gpsPoints: Seq[GPSPoint]) = {
-    val calcRoute = graphConf.mapMatching.doWork(gpsPoints.map(_.toGPXEntry))
+  override def matchingRoute(gpsPoints: Seq[GPSPoint]): Either[MatchedRouteError, MatchedRoute] = {
+    try {
+      val calcRoute = graphConf.mapMatching.doWork(gpsPoints.map(_.toGPXEntry))
 
-    val length = calcRoute.getMatchLength
-    val time = calcRoute.getMatchMillis
-    val edges: Seq[EdgeMatch] = calcRoute.getEdgeMatches
+      val length = calcRoute.getMatchLength
+      val time = calcRoute.getMatchMillis
+      val edges: Seq[EdgeMatch] = calcRoute.getEdgeMatches
 
-    if (calcRoute.getMergedPath.calcEdges().nonEmpty) {
+      if (calcRoute.getMergedPath.calcEdges().nonEmpty) {
 
-      val mappedEdges: Seq[(String, Double)] =
-        edges
-          .map(edge => (graphConf.encoder.getHighwayAsString(edge.getEdgeState), edge.getEdgeState.getDistance))
-          .map {
-            case (null, value) => ("unclassified", value)
-            case x: (String, Double) => x
-          }
+        val mappedEdges: Seq[(String, Double)] =
+          edges
+            .map(edge => (graphConf.encoder.getHighwayAsString(edge.getEdgeState), edge.getEdgeState.getDistance))
+            .map {
+              case (null, value) => ("unclassified", value)
+              case x: (String, Double) => x
+            }
 
-      //retrieve distance for each pair of points
-      val distances = calcRoute.getMergedPath
-        .calcDetails(List("distance"), new PathDetailsBuilderFactory, 0)
-        .get("distance")
+        //retrieve distance for each pair of points
+        val distances = calcRoute.getMergedPath
+          .calcDetails(List("distance"), new PathDetailsBuilderFactory, 0)
+          .get("distance")
 
-      //retrieve all edges
-      val allEdges: Seq[EnrichEdge] = edges.toList.flatMap(edge => {
-        val gpsExtensions: util.List[GPXExtension] = edge.getGpxExtensions
-        val edgeId = edge.getEdgeState.getBaseNode
+        //retrieve all edges
+        val allEdges: Seq[EnrichEdge] = edges.toList.flatMap(edge => {
+          val gpsExtensions: util.List[GPXExtension] = edge.getGpxExtensions
+          val edgeId = edge.getEdgeState.getBaseNode
 
-        if (gpsExtensions.size() == 0)
-          List(
-            EnrichEdge(edgeId, isInitialNode = false, typeOfRoute(edge), None)
-          )
-        else
-          gpsExtensions.flatMap(item => {
+          if (gpsExtensions.size() == 0)
             List(
-              EnrichEdge(
-                item.getQueryResult.getClosestNode,
-                isInitialNode = true,
-                typeOfRoute(edge),
-                Some(
-                  TracePoint(
-                    item.getEntry.lat,
-                    item.getEntry.lon,
-                    Some(item.getEntry.ele),
-                    item.getEntry.getTime,
-                    Some(item.getQueryResult.getSnappedPoint.lat),
-                    Some(item.getQueryResult.getSnappedPoint.lon),
-                    Some(item.getQueryResult.getSnappedPoint.ele),
-                    Some(typeOfRoute(edge)),
-                    Some(edge.getEdgeState.getName),
-                    Some(graphConf.encoder.getSpeed(item.getQueryResult.getClosestEdge.getFlags).toInt),
-                    Some(item.getQueryResult.getQueryDistance)
+              EnrichEdge(edgeId, isInitialNode = false, typeOfRoute(edge), None)
+            )
+          else
+            gpsExtensions.flatMap(item => {
+              List(
+                EnrichEdge(
+                  item.getQueryResult.getClosestNode,
+                  isInitialNode = true,
+                  typeOfRoute(edge),
+                  Some(
+                    TracePoint(
+                      item.getEntry.lat,
+                      item.getEntry.lon,
+                      Some(item.getEntry.ele),
+                      item.getEntry.getTime,
+                      Some(item.getQueryResult.getSnappedPoint.lat),
+                      Some(item.getQueryResult.getSnappedPoint.lon),
+                      Some(item.getQueryResult.getSnappedPoint.ele),
+                      Some(typeOfRoute(edge)),
+                      Some(edge.getEdgeState.getName),
+                      Some(graphConf.encoder.getSpeed(item.getQueryResult.getClosestEdge.getFlags).toInt),
+                      Some(item.getQueryResult.getQueryDistance)
+                    )
                   )
                 )
               )
-            )
-          })
+            })
 
-      })
+        })
 
-      //union information on edge with information on distances
-      val distancesBetweenEdge: Seq[EnrichEdgeWithDistance] =
-        allEdges.zip(distances).map {
-          case (edge, distance) =>
-            EnrichEdgeWithDistance(
-              edge.idNode,
-              edge.isInitialNode,
-              edge.typeOfRoute,
-              edge.node,
-              distance.getValue.asInstanceOf[Double]
-            )
-        }
-
-      //retrieve index of only initialNode
-      val idxInitialNode: Seq[Int] =
-        distancesBetweenEdge.zipWithIndex
-          .filter {
-            case (edgeWithDistance, idx) => edgeWithDistance.isInitialNode
-          }
-          .map {
-            case (edgeWithDistance, idx) => idx
-          }
-
-      // distances between node
-      val distancesBetweenNode =
-        idxInitialNode
-          .zip(idxInitialNode.tail)
-          .map {
-            case (fromIdx, toIdx) =>
-              val subList = distancesBetweenEdge.subList(fromIdx, toIdx + 1)
-
-              val (typesOfRoute, nrOccurrences) =
-                subList
-                  .map(_.typeOfRoute)
-                  .groupBy(identity)
-                  .mapValues(_.size)
-                  .reduce((a, b) => if (a._2 > b._2) a else b)
-
-              val distance =
-                subList
-                  .foldLeft(0D)((acc, elem) => {
-                    acc + elem.distance
-                  })
-
-              DistancePoint(
-                subList.head.node.get,
-                subList.last.node.get,
-                distance,
-                subList.last.node.get.time - subList.head.node.get.time,
-                typesOfRoute
+        //union information on edge with information on distances
+        val distancesBetweenEdge: Seq[EnrichEdgeWithDistance] =
+          allEdges.zip(distances).map {
+            case (edge, distance) =>
+              EnrichEdgeWithDistance(
+                edge.idNode,
+                edge.isInitialNode,
+                edge.typeOfRoute,
+                edge.node,
+                distance.getValue.asInstanceOf[Double]
               )
           }
 
-      val routeTypesKm: Map[String, Double] =
-        mappedEdges
-          .groupBy(_._1)
-          .map(x => (x._1, x._2.map(_._2).sum))
+        //retrieve index of only initialNode
+        val idxInitialNode: Seq[Int] =
+          distancesBetweenEdge.zipWithIndex
+            .filter {
+              case (edgeWithDistance, idx) => edgeWithDistance.isInitialNode
+            }
+            .map {
+              case (edgeWithDistance, idx) => idx
+            }
 
-      val points: Seq[TracePoint] =
-        allEdges.filter(_.isInitialNode).map(_.node.get)
+        // distances between node
+        val distancesBetweenNode =
+          idxInitialNode
+            .zip(idxInitialNode.tail)
+            .map {
+              case (fromIdx, toIdx) =>
+                val subList = distancesBetweenEdge.subList(fromIdx, toIdx + 1)
 
-      MatchedRoute(
-        points,
-        length,
-        time,
-        routeTypesKm,
-        distancesBetweenNode
-      )
-    } else
-        MatchedRoute(gpsPoints.map(_.toTracePoint), length, time, Map.empty, Seq.empty)
-  }
+                val (typesOfRoute, nrOccurrences) =
+                  subList
+                    .map(_.typeOfRoute)
+                    .groupBy(identity)
+                    .mapValues(_.size)
+                    .reduce((a, b) => if (a._2 > b._2) a else b)
 
-  override def matchingRoute(gpsPoints: Seq[GPSPoint]): Either[MatchedRouteError, MatchedRoute] = {
-    Try(getMatchingRoute(gpsPoints)) match {
-      case Success(matchingRoute) => Right(matchingRoute)
-      case Failure(ex) => Left(MatchedRouteError(ex))
+                val distance =
+                  subList
+                    .foldLeft(0D)((acc, elem) => {
+                      acc + elem.distance
+                    })
+
+                DistancePoint(
+                  subList.head.node.get,
+                  subList.last.node.get,
+                  distance,
+                  subList.last.node.get.time - subList.head.node.get.time,
+                  typesOfRoute
+                )
+            }
+
+        val routeTypesKm: Map[String, Double] =
+          mappedEdges
+            .groupBy(_._1)
+            .map(x => (x._1, x._2.map(_._2).sum))
+
+        val points: Seq[TracePoint] =
+          allEdges.filter(_.isInitialNode).map(_.node.get)
+
+        Right(MatchedRoute(
+          points,
+          length,
+          time,
+          routeTypesKm,
+          distancesBetweenNode
+        ))
+      } else
+          Right(MatchedRoute(gpsPoints.map(_.toTracePoint), length, time, Map.empty, Seq.empty))
+    } catch {
+      case ex: _ => Left(MatchedRouteError(ex))
     }
   }
 }

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
@@ -70,3 +70,10 @@ case class MatchedRoute(points: Seq[TracePoint],
   }
 
 }
+
+/**
+ * Matcher route error.
+ *
+ * @param ex error reason.
+ */
+case class MatchedRouteError(ex: Throwable)

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
@@ -70,10 +70,3 @@ case class MatchedRoute(points: Seq[TracePoint],
   }
 
 }
-
-/**
- * Matcher route error.
- *
- * @param ex error reason.
- */
-case class MatchedRouteError(ex: Throwable)

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
@@ -1,10 +1,10 @@
 package it.agilelab.bigdata.gis.domain.loader
 
 import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
-import it.agilelab.bigdata.gis.domain.models.ReverseGeocodingResponse
+import it.agilelab.bigdata.gis.domain.models.{ReverseGeocodingError, ReverseGeocodingResponse}
 
 trait ReverseGeocoder {
 
-  def reverseGeocode(point: GPSPoint) : ReverseGeocodingResponse
+  def reverseGeocode(point: GPSPoint) : Either[ReverseGeocodingError, ReverseGeocodingResponse]
 
 }

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
@@ -1,7 +1,8 @@
 package it.agilelab.bigdata.gis.domain.loader
 
+import it.agilelab.bigdata.gis.domain.exceptions.ReverseGeocodingError
 import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
-import it.agilelab.bigdata.gis.domain.models.{ReverseGeocodingError, ReverseGeocodingResponse}
+import it.agilelab.bigdata.gis.domain.models.ReverseGeocodingResponse
 
 trait ReverseGeocoder {
 

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/loader/RouteMatcher.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/loader/RouteMatcher.scala
@@ -1,6 +1,7 @@
 package it.agilelab.bigdata.gis.domain.loader
 
-import it.agilelab.bigdata.gis.domain.graphhopper.{GPSPoint, MatchedRoute, MatchedRouteError}
+import it.agilelab.bigdata.gis.domain.exceptions.MatchedRouteError
+import it.agilelab.bigdata.gis.domain.graphhopper.{GPSPoint, MatchedRoute}
 
 trait RouteMatcher {
 

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/loader/RouteMatcher.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/loader/RouteMatcher.scala
@@ -1,8 +1,8 @@
 package it.agilelab.bigdata.gis.domain.loader
 
-import it.agilelab.bigdata.gis.domain.graphhopper.{GPSPoint, MatchedRoute}
+import it.agilelab.bigdata.gis.domain.graphhopper.{GPSPoint, MatchedRoute, MatchedRouteError}
 
 trait RouteMatcher {
 
-  def matchingRoute(gpsPoints: Seq[GPSPoint]): MatchedRoute
+  def matchingRoute(gpsPoints: Seq[GPSPoint]): Either[MatchedRouteError, MatchedRoute]
 }

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
@@ -23,7 +23,9 @@ case class OSMManager(conf: Config) extends ReverseGeocoder with Logger {
     val queryPoint: Point = new GeometryFactory().createPoint(new Coordinate(point.lon, point.lat))
     Try(makeAddress(reverseGeocodeQueryingBoundaries(queryPoint), reverseGeocodeQueryingStreets(queryPoint), queryPoint)) match {
       case Success(addr) => Right(addr)
-      case Failure(ex) => Left(ReverseGeocodingError(ex))
+      case Failure(ex) =>
+        logger.error("Failed to reverse geocode points", ex)
+        Left(ReverseGeocodingError(ex))
     }
   }
 

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
@@ -4,9 +4,10 @@ import com.typesafe.config.Config
 import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory, Point}
 import it.agilelab.bigdata.gis.core.utils.{Logger, ManagerUtils}
 import it.agilelab.bigdata.gis.domain.configuration.OSMManagerConfiguration
+import it.agilelab.bigdata.gis.domain.exceptions.ReverseGeocodingError
 import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
 import it.agilelab.bigdata.gis.domain.loader.ReverseGeocoder
-import it.agilelab.bigdata.gis.domain.models.{KnnResult, OSMBoundary, OSMStreetAndHouseNumber, ReverseGeocodingError, ReverseGeocodingResponse}
+import it.agilelab.bigdata.gis.domain.models.{KnnResult, OSMBoundary, OSMStreetAndHouseNumber, ReverseGeocodingResponse}
 import it.agilelab.bigdata.gis.domain.spatialList.GeometryList
 import it.agilelab.bigdata.gis.domain.spatialOperator.KNNQueryMem
 

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/managers/OSMManager.scala
@@ -6,20 +6,24 @@ import it.agilelab.bigdata.gis.core.utils.{Logger, ManagerUtils}
 import it.agilelab.bigdata.gis.domain.configuration.OSMManagerConfiguration
 import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
 import it.agilelab.bigdata.gis.domain.loader.ReverseGeocoder
-import it.agilelab.bigdata.gis.domain.models.{KnnResult, OSMBoundary, OSMStreetAndHouseNumber, ReverseGeocodingResponse}
+import it.agilelab.bigdata.gis.domain.models.{KnnResult, OSMBoundary, OSMStreetAndHouseNumber, ReverseGeocodingError, ReverseGeocodingResponse}
 import it.agilelab.bigdata.gis.domain.spatialList.GeometryList
 import it.agilelab.bigdata.gis.domain.spatialOperator.KNNQueryMem
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 case class OSMManager(conf: Config) extends ReverseGeocoder with Logger {
 
   val osmConfig: OSMManagerConfiguration = OSMManagerConfiguration(conf)
   val indexManager: IndexManager = IndexManager(osmConfig.indexConf)
 
-  override def reverseGeocode(point: GPSPoint): ReverseGeocodingResponse = {
+  override def reverseGeocode(point: GPSPoint): Either[ReverseGeocodingError, ReverseGeocodingResponse] = {
     val queryPoint: Point = new GeometryFactory().createPoint(new Coordinate(point.lon, point.lat))
-    makeAddress(reverseGeocodeQueryingBoundaries(queryPoint), reverseGeocodeQueryingStreets(queryPoint), queryPoint)
+    Try(makeAddress(reverseGeocodeQueryingBoundaries(queryPoint), reverseGeocodeQueryingStreets(queryPoint), queryPoint)) match {
+      case Success(addr) => Right(addr)
+      case Failure(ex) => Left(ReverseGeocodingError(ex))
+    }
   }
 
   private def reverseGeocodeQueryingBoundaries(queryPoint: Point): Option[(OSMBoundary, KnnResult)] = {

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
@@ -52,3 +52,10 @@ case class ReverseGeocodingResponse(street: Option[String],
                                     speedCategory: Option[String] = None,
                                     roadType: Option[String] = None,
                                     distance: Option[Double] = None) extends OutputModel
+
+/**
+ * Reverse geocoding error.
+ *
+ * @param ex error cause.
+ */
+case class ReverseGeocodingError(ex: Throwable)

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
@@ -52,10 +52,3 @@ case class ReverseGeocodingResponse(street: Option[String],
                                     speedCategory: Option[String] = None,
                                     roadType: Option[String] = None,
                                     distance: Option[Double] = None) extends OutputModel
-
-/**
- * Reverse geocoding error.
- *
- * @param ex error cause.
- */
-case class ReverseGeocodingError(ex: Throwable)

--- a/src/test/scala/it/agilelab/bigdata/gis/domain/loader/OSMManagerSpec.scala
+++ b/src/test/scala/it/agilelab/bigdata/gis/domain/loader/OSMManagerSpec.scala
@@ -4,9 +4,9 @@ import com.typesafe.config.{Config, ConfigFactory}
 import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
 import it.agilelab.bigdata.gis.domain.managers.OSMManager
 import it.agilelab.bigdata.gis.domain.models.ReverseGeocodingResponse
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, EitherValues, FlatSpec, Matchers}
 
-class OSMManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class OSMManagerSpec extends FlatSpec with Matchers with EitherValues with BeforeAndAfterAll {
 
   val conf: Config = ConfigFactory.load()
   val osmConf: Config = conf.getConfig("osm")
@@ -14,7 +14,7 @@ class OSMManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   "Reverse geocoding on Andorra" should "work" in {
     val point = GPSPoint(42.542703, 1.515542, None, System.currentTimeMillis())
-    val randomPlaceInAndorraActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point)
+    val randomPlaceInAndorraActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point).right.value
 
     val randomPlaceInAndorraExpected: ReverseGeocodingResponse =
       ReverseGeocodingResponse(
@@ -40,7 +40,7 @@ class OSMManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val point = GPSPoint(45.068032, 7.643780, None, System.currentTimeMillis())
 
-    val viaAzziActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point)
+    val viaAzziActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point).right.value
 
     val viaAzziExpected: ReverseGeocodingResponse =
       ReverseGeocodingResponse(


### PR DESCRIPTION
# New features and improvements

- Use `Either[MatchedRouteError, MatchedRoute]` as return value of `RouteMatcher.match` 
- Use `Either[ReverseGeocodingError, ReverseGeocodingResponse]` as return value of `ReverseGeocoder.reverseGeocode` 

# Related issue

Closes #32