### PR TITLE
Add id to ReverseGeocodingResponse and GPSPoint

### DIFF
--- a/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/graphhopper/MatchedRoute.scala
@@ -11,7 +11,7 @@ import scala.util.Try
  * @param alt  input altitude
  * @param time input time
  */
-case class GPSPoint(lat: Double, lon: Double, alt: Option[Double], time: Long) {
+class GPSPoint(val lat: Double, val lon: Double, val alt: Option[Double], val time: Long) {
 
   def toTracePoint: TracePoint = {
     TracePoint(
@@ -31,6 +31,26 @@ case class GPSPoint(lat: Double, lon: Double, alt: Option[Double], time: Long) {
   def toGPXEntry: GPXEntry = new GPXEntry(lat, lon, time)
 
 }
+
+object GPSPoint {
+
+  def apply(lat: Double, lon: Double, alt: Option[Double], time: Long) = new GPSPoint(lat, lon, alt, time)
+}
+
+/**
+ * IdentifiableGPSPoint is a GPSPoint with an id.
+ *
+ * @param id   GPS point id
+ * @param lat  input latitude
+ * @param lon  input longitude
+ * @param alt  input altitude
+ * @param time input time
+ */
+case class IdentifiableGPSPoint(id: String,
+                                override val lat: Double,
+                                override val lon: Double,
+                                override val alt: Option[Double],
+                                override val time: Long) extends GPSPoint(lat, lon, alt, time)
 
 /**
  *

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/loader/ReverseGeocoder.scala
@@ -1,11 +1,11 @@
 package it.agilelab.bigdata.gis.domain.loader
 
 import it.agilelab.bigdata.gis.domain.exceptions.ReverseGeocodingError
-import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
+import it.agilelab.bigdata.gis.domain.graphhopper.IdentifiableGPSPoint
 import it.agilelab.bigdata.gis.domain.models.ReverseGeocodingResponse
 
 trait ReverseGeocoder {
 
-  def reverseGeocode(point: GPSPoint) : Either[ReverseGeocodingError, ReverseGeocodingResponse]
+  def reverseGeocode(point: IdentifiableGPSPoint) : Either[ReverseGeocodingError, ReverseGeocodingResponse]
 
 }

--- a/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/domain/models/ReverseGeocodingResponse.scala
@@ -4,10 +4,12 @@ import it.agilelab.bigdata.gis.core.model.output.OutputModel
 
 object ReverseGeocodingResponse {
 
-  def apply(osmStreet: OSMStreetAndHouseNumber,
+  def apply(id: String,
+            osmStreet: OSMStreetAndHouseNumber,
             osmBoundary: OSMBoundary,
             distanceAndNumber: (Double, Option[String])): ReverseGeocodingResponse = {
     ReverseGeocodingResponse(
+      id,
       osmStreet.street,
       osmBoundary.city,
       osmBoundary.county,
@@ -23,8 +25,9 @@ object ReverseGeocodingResponse {
       Some(distanceAndNumber._1))
   }
 
-  def apply(osmStreet: Option[OSMStreet], osmBoundary: Option[OSMBoundary]): ReverseGeocodingResponse = {
+  def apply(id: String, osmStreet: Option[OSMStreet], osmBoundary: Option[OSMBoundary]): ReverseGeocodingResponse = {
     ReverseGeocodingResponse(
+      id,
       osmStreet.flatMap(_.street),
       osmBoundary.flatMap(_.city),
       osmBoundary.flatMap(_.county),
@@ -39,7 +42,8 @@ object ReverseGeocodingResponse {
 
 }
 
-case class ReverseGeocodingResponse(street: Option[String],
+case class ReverseGeocodingResponse(id: String,
+                                    street: Option[String],
                                     city: Option[String],
                                     county: Option[String],
                                     countyCode: Option[String],

--- a/src/test/scala/it/agilelab/bigdata/gis/domain/loader/OSMManagerSpec.scala
+++ b/src/test/scala/it/agilelab/bigdata/gis/domain/loader/OSMManagerSpec.scala
@@ -1,7 +1,7 @@
 package it.agilelab.bigdata.gis.domain.loader
 
 import com.typesafe.config.{Config, ConfigFactory}
-import it.agilelab.bigdata.gis.domain.graphhopper.GPSPoint
+import it.agilelab.bigdata.gis.domain.graphhopper.{GPSPoint, IdentifiableGPSPoint}
 import it.agilelab.bigdata.gis.domain.managers.OSMManager
 import it.agilelab.bigdata.gis.domain.models.ReverseGeocodingResponse
 import org.scalatest.{BeforeAndAfterAll, EitherValues, FlatSpec, Matchers}
@@ -13,11 +13,13 @@ class OSMManagerSpec extends FlatSpec with Matchers with EitherValues with Befor
   val osmManager: OSMManager = OSMManager(osmConf)
 
   "Reverse geocoding on Andorra" should "work" in {
-    val point = GPSPoint(42.542703, 1.515542, None, System.currentTimeMillis())
+    val id = "abc"
+    val point = IdentifiableGPSPoint(id, 42.542703, 1.515542, None, System.currentTimeMillis())
     val randomPlaceInAndorraActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point).right.value
 
     val randomPlaceInAndorraExpected: ReverseGeocodingResponse =
       ReverseGeocodingResponse(
+        id,
         street = Some(""),
         city = Some("La Massana"),
         county = None,
@@ -38,12 +40,14 @@ class OSMManagerSpec extends FlatSpec with Matchers with EitherValues with Befor
 
   "Reverse geocoding on Italy" should "work" in {
 
-    val point = GPSPoint(45.068032, 7.643780, None, System.currentTimeMillis())
+    val id = "abc"
+    val point = IdentifiableGPSPoint(id, 45.068032, 7.643780, None, System.currentTimeMillis())
 
     val viaAzziActual: ReverseGeocodingResponse = osmManager.reverseGeocode(point).right.value
 
     val viaAzziExpected: ReverseGeocodingResponse =
       ReverseGeocodingResponse(
+        id,
         street = Some("Via Francesco Azzi"),
         city = Some("Turin"),
         county = Some("Torino"),


### PR DESCRIPTION
# New features and improvements

- Add id to `ReverseGeocodingResponse`
- Add `IdentifiableGPSPoint` class which extends GPSPoint and adds an
  id to it.

# Related issue

Closes #47