### PR TITLE
Add more highways to the car flag encoder's highway list

### DIFF
--- a/src/main/scala/it/agilelab/bigdata/gis/core/encoder/CarFlagEncoderEnrich.scala
+++ b/src/main/scala/it/agilelab/bigdata/gis/core/encoder/CarFlagEncoderEnrich.scala
@@ -52,7 +52,13 @@ class CarFlagEncoderEnrich(speedBits: Int = 5, speedFactor: Double = 5, maxTurnC
     "cycleway",
     "path",
     "footway",
-    "pedestrian"
+    "pedestrian",
+    "bus_guideway",
+    "escape",
+    "raceway",
+    "busway",
+    "bridleway",
+    "steps"
   )
 
   highwayList.zipWithIndex.foreach { case (value, idx) =>


### PR DESCRIPTION
As reported by OSM [1], those are highways too.

1. https://wiki.openstreetmap.org/wiki/Key:highway