### PR TITLE
[#78] Revert #69

### DIFF
--- a/src/main/scala/it/agilelab/gis/core/encoder/CarFlagEncoderEnrich.scala
+++ b/src/main/scala/it/agilelab/gis/core/encoder/CarFlagEncoderEnrich.scala
@@ -53,13 +53,7 @@ class CarFlagEncoderEnrich(speedBits: Int = 5, speedFactor: Double = 5, maxTurnC
     "cycleway",
     "path",
     "footway",
-    "pedestrian",
-    "bus_guideway",
-    "escape",
-    "raceway",
-    "busway",
-    "bridleway",
-    "steps"
+    "pedestrian"
   )
 
   highwayList.zipWithIndex.foreach { case (value, idx) =>


### PR DESCRIPTION
# Hotfix

This hotfix include:
- Revert MR #69: it leads to an incorrect recovery of the road type
- Revert MR #69: is impossible generate a new graph because the default values ​​for the street type adds in #69 are missing