### PR TITLE
[#104] Revert circle distance method

### DIFF
--- a/src/main/scala/it/agilelab/gis/core/model/geometry/Circle.scala
+++ b/src/main/scala/it/agilelab/gis/core/model/geometry/Circle.scala
@@ -125,10 +125,11 @@ case class Circle(center: Point, radius: Double, circleFactory: GeometryFactoryE
   /** Compute the distance from the circle side
     *
     * @param geom other geometry to compare with
-    * @return the distance from the circle side (negative if the geometry is within the circle)
+    * @return the distance from the circle side (zero if the geometry is within the circle)
     */
   override def distance(geom: Geometry) =
-    this.center.distance(geom) - radius
+    if (!this.contains(geom)) this.center.distance(geom) - radius
+    else 0.0
 
   /** Geometry type
     *

--- a/src/test/scala/it/agilelab/gis/core/GeometryDistanceSpec.scala
+++ b/src/test/scala/it/agilelab/gis/core/GeometryDistanceSpec.scala
@@ -24,12 +24,12 @@ class GeometryDistanceSpec extends FlatSpec with Matchers {
 
   }
 
-  it should "return negative distance from a point because internal" in {
+  it should "return zero distance from a point because internal" in {
     val wktStringCircle: String = "CIRCLE((100 100),50)"
     val wktStringPoint: String = "POINT(70 100)"
     val circle = WktConverter.converter(wktStringCircle)
     val point = WktConverter.converter(wktStringPoint)
-    val expected = -20d
+    val expected = 0d
     circle.right.get.distance(point.right.get) shouldEqual expected
 
   }


### PR DESCRIPTION
### New features and improvements
Reverted method to compute the distance between a generic point and the border of the circle.
If the point is inside or on the border, distance method returns zero

### Related issue
Closes #101