### PR TITLE
[#134] Enable release from GitHub action

### DIFF
--- a/.github/workflows/scala-release.yaml
+++ b/.github/workflows/scala-release.yaml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  push:
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      - name: release
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 addSbtPlugin("com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
## New features and improvements
Release workflow is started when a tag is pushed

## Related issue
Closes #134