### PR TITLE
[#136] Differentiate map matching error due to a broken sequence

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,8 +18,8 @@ trait Dependencies {
       ExclusionRule(organization = "com.fasterxml.jackson.core", name = "jackson-core")
     ),
     "com.graphhopper" % "graphhopper-core" % "0.11.0" exclude ("com.vividsolutions", "jts-core"),
-    "com.graphhopper" % "graphhopper-reader-osm" % "0.11.0",
-    "com.graphhopper" % "graphhopper-map-matching-core" % "0.11.0-4",
+    "com.graphhopper" % "graphhopper-reader-osm" % "0.11.0" exclude ("com.vividsolutions", "jts-core"),
+    "com.graphhopper" % "graphhopper-map-matching-core" % "0.11.0-4" exclude ("com.vividsolutions", "jts-core"),
     "org.scalatest" %% "scalatest" % "3.0.4" % Test,
     "org.apache.xmlgraphics" % "xmlgraphics-commons" % "2.6" exclude ("commons-logging", "commons-logging")
   )

--- a/src/main/scala/it/agilelab/gis/domain/exceptions/package.scala
+++ b/src/main/scala/it/agilelab/gis/domain/exceptions/package.scala
@@ -1,6 +1,16 @@
 package it.agilelab.gis.domain
 
+import it.agilelab.gis.domain.graphhopper.GPSPoint
+
 package object exceptions {
+
+  /** Matcher route error.
+    */
+  sealed trait MatchedRouteError {
+    val ex: Throwable
+  }
+
+  sealed trait GeoRelationError
 
   /** Reverse geocoding error.
     *
@@ -8,13 +18,24 @@ package object exceptions {
     */
   case class ReverseGeocodingError(ex: Throwable)
 
-  /** Matcher route error.
+  /** Recoverable broken sequence error
+    *
+    * @param ex error reason.
+    * @param observation the point that caused the error
+    */
+  case class RecoverableBrokenSequenceRouteError(ex: Throwable, observation: GPSPoint) extends MatchedRouteError
+
+  /** Not recoverable broken sequence error
     *
     * @param ex error reason.
     */
-  case class MatchedRouteError(ex: Throwable)
+  case class NotRecoverableBrokenSequenceRouteError(ex: Throwable) extends MatchedRouteError
 
-  sealed trait GeoRelationError
+  /** Generic map matching error
+    *
+    * @param ex error reason.
+    */
+  case class GenericMatchedRouteError(ex: Throwable) extends MatchedRouteError
 
   /** Railways distance error.
     *


### PR DESCRIPTION
## New features and improvements
- MatchedRouteError is now a sealed trait
- Created RecoverableBrokenSequenceRouteError, NotRecoverableBrokenSequenceRouteError, GenericMatchedRouteError which extends MatchedRouteError
- a Left[RecoverableBrokenSequenceRouteError] is returned in GraphHopperManager.matchingRoute if exception message indicates a broken sequence and the observation point was extracted
- a Left[NotRecoverableBrokenSequenceRouteError] is returned in GraphHopperManager.matchingRoute if exception message indicates a broken sequence and the observation point was not extracted
- a Left[GenericMatchedRouteError] is returned in GraphHopperManager.matchingRoute in all other exception cases

## Breaking changes
- MatchedRouteError is now a sealed trait

## Migration
N/A

## Bug fixes
N/A

## Related issue
Closes #136